### PR TITLE
no longer removes <!DOCTYPE> on format

### DIFF
--- a/src/prettyprint.ts
+++ b/src/prettyprint.ts
@@ -130,6 +130,10 @@ export function format(src: string, indentation: number = 4, useSpaces: boolean 
     }
 
     htmlResult.rootNodes.forEach(node => {
+        const doctype = node.sourceSpan.start.getContext(20, 1).before;
+        if (doctype.includes('<!')) {
+            pretty.push(doctype);
+        }
         node.visit(visitor, {});
     })
 


### PR DESCRIPTION
fixes bug:

https://github.com/stringham/angular-template-formatter/issues/4