### PR TITLE
fix: detect doctype and add it to end result

### DIFF
--- a/src/prettyprint.ts
+++ b/src/prettyprint.ts
@@ -45,6 +45,12 @@ export function format(src: string, indentation: number = 4, useSpaces: boolean 
         'pre': true,
     };
 
+    const detectedDoctype = src.match(/^\s*<!DOCTYPE((.|\n|\r)*?)>/i);
+
+    if (detectedDoctype) {
+        pretty.push(detectedDoctype[0].trim());
+    }
+
     let getIndent = (i: number): string => {
         if (useSpaces) {
             return new Array(i * indentation).fill(' ').join('');


### PR DESCRIPTION
Current behavior, extension parse html and remove doctype from end result.

But we have problem with angular material which require us to set proper doctype for the document or some components will not work correctly.

This is a really good extension, the only thing that bothering us is doctype issue and this PR fix the problem.

Feel free to ask for change request if needed.

Regards,