### PR TITLE
feat: preserve SVG namespace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 out
 node_modules
 .angulardoc.json
+package-lock.json


### PR DESCRIPTION
feat: preserve SVG namespace
fix: avoid adding ':' at beginning of attribute-name

[issue](https://github.com/stringham/angular-template-formatter/issues/17)